### PR TITLE
US129952 - [Training] Add support for quiz-posted events in activity-summary

### DIFF
--- a/components/activity-event-quiz-posted.js
+++ b/components/activity-event-quiz-posted.js
@@ -1,0 +1,77 @@
+import './activity-event-common.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { LocalizeTrainingActivitySummaryMixin } from '../mixins/training-activity-summary-lang-mixin.js';
+import { QuizPostedEntity } from '../src/QuizPostedEntity.js';
+
+class ActivityEventQuizPosted extends LocalizeTrainingActivitySummaryMixin(EntityMixinLit(LitElement)) {
+
+	static get properties() {
+		return {
+			quizTitle: { type: String },
+			dueDate: { type: String }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			#due-date-detail {
+				border: 2px solid var(--d2l-color-primary-accent-indicator);
+				border-radius: 10px;
+				color: var(--d2l-color-primary-accent-indicator);
+				display: inline-block;
+				font-size: 0.8rem;
+				padding: 2px;
+			}
+			.description: {
+				font-size: 2rem;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this._setEntityType(QuizPostedEntity);
+		this.quizTitle = '';
+		this.dueDate = '';
+	}
+
+	render() {
+		return html`
+			<activity-event-common
+				.href=${this.href}
+				.token=${this.token}
+			>
+				<div slot="icon"><d2l-icon icon="tier3:quizzing"></d2l-icon></div>
+				<div slot="description">${this.localize('quiz:posted:description', 'quizTitle', this.quizTitle)}</div>
+				<div slot="details">
+					<div id="due-date-detail">${this.localize('quiz:posted:duedate', 'dueDate', this.dueDate)}</div>
+				</div>
+			</activity-event-common>
+		`;
+	}
+
+	set _entity(entity) {
+		if (this._entityHasChanged(entity)) {
+			this._onQuizPostedChanged(entity);
+		}
+
+		super._entity = entity;
+	}
+
+	_onQuizPostedChanged(quizPosted) {
+		if (quizPosted) {
+			this.quizTitle = quizPosted.quizTitle();
+			this.dueDate = quizPosted.dueDate();
+		}
+	}
+}
+customElements.define('activity-event-quiz-posted', ActivityEventQuizPosted);

--- a/lang/en.js
+++ b/lang/en.js
@@ -7,5 +7,6 @@ export default {
 	"assignment:overdue:description": "{assignmentTitle} is now overdue.",
 	"assignment:overdue:endDate": "End Date: {endDate}",
 	"quiz:posted:description": "A new quiz has been posted: {quizTitle}",
+	"quiz:posted:duedate": "Due Date: {dueDate}",
 	"summary:empty:message": "No recent activity at this time"
 };

--- a/src/QuizPostedEntity.js
+++ b/src/QuizPostedEntity.js
@@ -1,0 +1,21 @@
+import { ActivityEventEntity } from './ActivityEventEntity.js';
+import { formatDateTimeFromTimestamp } from '@brightspace-ui/intl/lib/dateTime.js';
+
+export class QuizPostedEntity extends ActivityEventEntity {
+	static get class() { return 'quiz-posted'; }
+
+	/**
+	 * @returns {string} due date of quiz
+	 */
+	dueDate() {
+		return this._entity
+			&& this._entity.properties
+			&& formatDateTimeFromTimestamp(this._entity.properties.dueDate,  { format: 'short' });
+	}
+	/**
+	 * @returns {string} title of the quiz that is being posted
+	 */
+	quizTitle() {
+		return this._entity && this._entity.properties && this._entity.properties.quizTitle;
+	}
+}

--- a/training-activity-summary.js
+++ b/training-activity-summary.js
@@ -1,11 +1,13 @@
 import './components/activity-event-assignment-graded.js';
 import './components/activity-event-assignment-overdue.js';
+import './components/activity-event-quiz-posted.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ActivitySummaryEntity } from './src/ActivitySummaryEntity.js';
 import { AssignmentGradedEntity } from './src/AssignmentGradedEntity.js';
 import { AssignmentOverdueEntity } from './src/AssignmentOverdueEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeTrainingActivitySummaryMixin } from './mixins/training-activity-summary-lang-mixin.js';
+import { QuizPostedEntity } from './src/QuizPostedEntity.js';
 
 class TrainingActivitySummary extends LocalizeTrainingActivitySummaryMixin(EntityMixinLit(LitElement)) {
 
@@ -74,6 +76,14 @@ class TrainingActivitySummary extends LocalizeTrainingActivitySummaryMixin(Entit
 					.token=${this.token}
 				>
 				</activity-event-assignment-overdue>
+			`;
+		} else if (eventEntity.class.includes(QuizPostedEntity.class)) {
+			return html`
+				<activity-event-quiz-posted
+					.href=${itemLinkHref}
+					.token=${this.token}
+				>
+				</activity-event-quiz-posted>
 			`;
 		} else {
 			return html``;


### PR DESCRIPTION
## Relevant Rally Links

https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fuserstory%2F603973034677&fdp=true



## Description

Adding quiz posted support to the activity summary. This task is to practice implementing something based on a mock and familiarize myself with the technologies that mimic the way the front end is implemented.



## Goal/Solution

- Added an entity to represent a posted quiz.
- Created a component for the newly created quiz entity
- Extended the activity summary to add a posted quiz element if there is an appropriate quiz posted event.
- Added due date to the language english file.



## Video/Screenshots

![image](https://user-images.githubusercontent.com/91631476/137382238-ebb5a539-6a4e-49e4-b46d-c69c8b82e116.png)
